### PR TITLE
Update old/dead exercise links.

### DIFF
--- a/modules/monitoring.md
+++ b/modules/monitoring.md
@@ -31,7 +31,7 @@
    * [When to use the different log levels `Thread`](https://stackoverflow.com/questions/2031163/when-to-use-the-different-log-levels/64806781#64806781)
 
    #### Exercises
-   * [Collecting Telemetry Data](../exercises/monitoring/collecting-telemetry.md)
+   * [Collecting Telemetry Data](../exercises/monitoring/collecting-telemetry-data.md)
    * Integrate Sentry.io in an application to collect crash reports
    * Integrate DataDog into an application
 </details>

--- a/modules/operations.md
+++ b/modules/operations.md
@@ -124,5 +124,5 @@
    * [What's the Difference Between DevOps and SRE? `Video`](https://www.youtube.com/watch?v=uTEL8Ff1Zvk)
 
    #### Exercises
-   * [Reduce Toil](../exercises/reduce-toil.md)
+   * [Reduce Toil](../exercises/operations/reduce-toil.md)
 </details>


### PR DESCRIPTION
This change updates two dead `/exercise` links discovered while touring through EngineerKit.
Thanks for such a great resource! :tada: 