### PR TITLE
Add link validation workflow action.

### DIFF
--- a/.github/workflows/ignored-links.config.json
+++ b/.github/workflows/ignored-links.config.json
@@ -1,0 +1,7 @@
+{
+    "ignorePatterns": [
+      {
+        "pattern": "^(.*)cloudflare.com(.*)"
+      }
+    ]
+  }

--- a/.github/workflows/validate-links.yml
+++ b/.github/workflows/validate-links.yml
@@ -1,0 +1,19 @@
+name: Markdown Links Check
+
+on:
+  push:
+    branches: [ main ]
+  schedule:
+    #Every Monday at 9:15AM
+    - cron: "15 9 * * 1"
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        use-verbose-mode: 'yes'
+        config-file: '.github/workflows/ignored-links.config.json'


### PR DESCRIPTION
The workflow action is set to run whenever a push is made to the main branch, and it will also run every Monday at 9:15 AM. Feel free to adjust the time to your liking. [Crontab.guru](https://crontab.guru/) is a great tool if you're like me and don't remember cron notation off the top of your head. :laughing: 

Drawbacks I've noticed:
- I've had to ignore Cloudflare links as their DDoS protection, even with a custom user agent, blocks the link validator's requests.
- Certain sites provoke a redirection loop. Currently it seems that [https://developer.android.com/studio](https://developer.android.com/studio) in /modules/tooling.md suffers from this issue, despite the site being accessible via a browser.
- If you have any syntax errors in your yaml or json files the workflow will run without any errors. However, instead of taking several minutes, it will only run for ~60 seconds before completing. That is the only consistent indication that I should check my syntax that I've found..

Overall it seems to work and in my tests it did catch a handful of dead links. I only wish it were more accurate. 

Fixes #19 